### PR TITLE
bug fix/ generating random IP for network & refactor

### DIFF
--- a/code/Attack/DrupalScan.py
+++ b/code/Attack/DrupalScan.py
@@ -75,16 +75,6 @@ class DrupalScan(BaseAttack.BaseAttack):
             return False
         return self.add_param_value(param, value)
     
-    """
-    Generate SQL convo parameters 
-    """
-    def generate_sql_param(self): 
-        ip_addresses_in_use = self.statistics.get_ip_addresses()
-        ip_attakcer = self.get_param_value(self.IP_DESTINATION) # attacker ip 
-        subnet_mask = "255.255.255.0"
-        ip_sql = self.get_unique_random_ipv4_from_ip_network(ip_attakcer, subnet_mask,ip_addresses_in_use)
-        mac_sql = self.generate_random_mac_address() 
-        return mac_sql, ip_sql
 
     """
     Creates the attack packets
@@ -130,7 +120,7 @@ class DrupalScan(BaseAttack.BaseAttack):
             mss_value = 1465
 
         # Communication is between server & its db 
-        mac_sql, ip_sql = self.generate_sql_param()
+        mac_sql, ip_sql = self.generate_sql_victim_conv_param(ip_destination)
 
         arrival_time = 0
         exploit_raw_packets = scapy.utils.RawPcapReader(self.template_scan_pcap_path)

--- a/code/Attack/JoomlaScan.py
+++ b/code/Attack/JoomlaScan.py
@@ -78,18 +78,6 @@ class JoomlaScan(BaseAttack.BaseAttack):
             return False
         return self.add_param_value(param, value)
 
-
-    """
-    Generate SQL convo parameters 
-    """
-    def generate_sql_param(self): 
-        ip_addresses_in_use = self.statistics.get_ip_addresses()
-        ip_attakcer = self.get_param_value(self.IP_DESTINATION) # attacker ip 
-        subnet_mask = "255.255.255.0"
-        ip_sql = self.get_unique_random_ipv4_from_ip_network(ip_attakcer, subnet_mask,ip_addresses_in_use)
-        mac_sql = self.generate_random_mac_address() 
-        return mac_sql, ip_sql
-
     """
     Creates the attack packets
     """
@@ -134,7 +122,7 @@ class JoomlaScan(BaseAttack.BaseAttack):
             mss_value = 1465
 
         # Communication is between server & its db 
-        mac_sql, ip_sql = self.generate_sql_param()
+        mac_sql, ip_sql = self.generate_sql_victim_conv_param(ip_destination)
 
         arrival_time = 0
         exploit_raw_packets = scapy.utils.RawPcapReader(self.template_scan_pcap_path)

--- a/code/Attack/Log4ShellExploit.py
+++ b/code/Attack/Log4ShellExploit.py
@@ -164,7 +164,7 @@ class Log4ShellExploit(BaseAttack.BaseAttack):
                 self.statistics.get_most_used_ttl_value())
 
         # Set Window Size based on Window Size distribution of IP address
-        source_win_prob_dict = self.get_window_distribution(self, ip_source)
+        source_win_prob_dict = self.get_window_distribution(ip_source)
         destination_win_prob_dict = self.get_window_distribution( ip_destination)
         
         # Set MSS (Maximum Segment Size) based on MSS distribution of IP address

--- a/code/Attack/WordpressScan.py
+++ b/code/Attack/WordpressScan.py
@@ -79,18 +79,6 @@ class WordpressScan(BaseAttack.BaseAttack):
             return False
         return self.add_param_value(param, value)
 
-    
-    """
-    Generate SQL convo parameters 
-    """
-    def generate_sql_param(self): 
-        ip_addresses_in_use = self.statistics.get_ip_addresses()
-        ip_attakcer = self.get_param_value(self.IP_DESTINATION) # attacker ip 
-        subnet_mask = "255.255.255.0"
-        ip_sql = self.get_unique_random_ipv4_from_ip_network(ip_attakcer, subnet_mask,ip_addresses_in_use)
-        mac_sql = self.generate_random_mac_address() 
-        return mac_sql, ip_sql
-
     """
     Creates the attack packets
     """
@@ -135,7 +123,7 @@ class WordpressScan(BaseAttack.BaseAttack):
             mss_value = 1465
 
         # Communication is between server & its db 
-        mac_sql, ip_sql = self.generate_sql_param()
+        mac_sql, ip_sql = self.generate_sql_victim_conv_param(ip_destination)
 
         arrival_time = 0
         exploit_raw_packets = scapy.utils.RawPcapReader(self.template_scan_pcap_path)


### PR DESCRIPTION
- The bug happened because the list of ips in use were not filtered by network, now it is fixed such that the comparison looks at the IPs in use in the network before generating a new random one.
- function for generating mac & ip address for conv with sql has been refactored to baseAttack.